### PR TITLE
add Qualifier to http clients

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/service/token/ServiceTokenParserConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/service/token/ServiceTokenParserConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.auth.parser.idam.spring.service.token;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/service/token/ServiceTokenParserConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/service/token/ServiceTokenParserConfiguration.java
@@ -7,8 +7,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
-import uk.gov.hmcts.reform.auth.parser.idam.core.service.token.ServiceTokenParser;
 import uk.gov.hmcts.reform.auth.parser.idam.core.service.token.HttpComponentsBasedServiceTokenParser;
+import uk.gov.hmcts.reform.auth.parser.idam.core.service.token.ServiceTokenParser;
 
 @Configuration
 @Lazy
@@ -21,10 +21,10 @@ public class ServiceTokenParserConfiguration {
     }
 
     @Bean
-    public ServiceTokenParser serviceAuthProviderAuthCheckClient(HttpClient serviceTokenParserHttpClient,
-                                                                 @Value("${auth.provider.service.client.baseUrl}") String baseUrl) {
-
-        return new HttpComponentsBasedServiceTokenParser(serviceTokenParserHttpClient, baseUrl);
+    public ServiceTokenParser serviceAuthProviderAuthCheckClient(
+        @Qualifier("serviceTokenParserHttpClient") HttpClient serviceTokenParserHttpClient,
+        @Value("${auth.provider.service.client.baseUrl}") String baseUrl) {
+            return new HttpComponentsBasedServiceTokenParser(serviceTokenParserHttpClient, baseUrl);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/user/token/UserTokenParserConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/user/token/UserTokenParserConfiguration.java
@@ -22,9 +22,10 @@ public class UserTokenParserConfiguration {
     }
 
     @Bean
-    public UserTokenParser<UserTokenDetails> userTokenParser(HttpClient userTokenParserHttpClient,
-                                                             @Value("${auth.idam.client.baseUrl}") String baseUrl) {
-        return new HttpComponentsBasedUserTokenParser<>(userTokenParserHttpClient, baseUrl, UserTokenDetails.class);
+    public UserTokenParser<UserTokenDetails> userTokenParser(
+        @Qualifier("userTokenParserHttpClient") HttpClient userTokenParserHttpClient,
+        @Value("${auth.idam.client.baseUrl}") String baseUrl) {
+            return new HttpComponentsBasedUserTokenParser<>(userTokenParserHttpClient, baseUrl, UserTokenDetails.class);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/user/token/UserTokenParserConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/user/token/UserTokenParserConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.auth.parser.idam.spring.user.token;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
 . add Qualifier to http clients
in spring boot 3.2 upgrade we get error in initialisation saying that it finds 2 beans
 ```No qualifying bean of type 'org.apache.http.client.HttpClient' available: expected single matching bean but found 2: userTokenParserHttpClient,serviceTokenParserHttpClient```

`Parameter 0 of method userTokenParser in uk.gov.hmcts.reform.auth.parser.idam.spring.user.token.UserTokenParserConfiguration required a single bean, but 2 were found:
	- userTokenParserHttpClient: defined by method 'userTokenParserHttpClient' in class path resource [uk/gov/hmcts/reform/auth/parser/idam/spring/user/token/UserTokenParserConfiguration.class]
	- serviceTokenParserHttpClient: defined by method 'serviceTokenParserHttpClient' in class path resource [uk/gov/hmcts/reform/auth/parser/idam/spring/service/token/ServiceTokenParserConfiguration.class]`
