### PR TITLE
Update qualifier usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A library for verifying user/service "Bearer" tokens and enforcing coarse graine
        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
            http
                .addFilter(filter)
-               .authorizeHttpRequests((authorizeHttpRequests) ->
+               .authorizeHttpRequests(authorizeHttpRequests ->
                     authorizeHttpRequests.anyRequest().authenticated()
                 );
             return http.build();
@@ -38,7 +38,7 @@ A library for verifying user/service "Bearer" tokens and enforcing coarse graine
    this level and more fine-grained using standard spring-security approach (e.g. @Secured annotation at class/method level)
    ```java
    
-   @Bean(value = "authorizedRolesExtractor")
+   @Bean("authorizedRolesExtractor")
    public Function<HttpServletRequest, Collection<String>> authorizedRolesExtractor() {
        return (anyRequest) -> Collections.singletonList("citizen");
    }
@@ -72,7 +72,7 @@ A library for verifying user/service "Bearer" tokens and enforcing coarse graine
        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
            http
                .addFilter(filter)
-               .authorizeHttpRequests((authorizeHttpRequests) ->
+               .authorizeHttpRequests(authorizeHttpRequests ->
                     authorizeHttpRequests.anyRequest().authenticated()
                 );
             return http.build();
@@ -83,7 +83,7 @@ A library for verifying user/service "Bearer" tokens and enforcing coarse graine
    list based on some application property
    ```java
    
-   @Bean(value = "authorizedServiceExtractor")
+   @Bean("authorizedServiceExtractor")
    public Function<HttpServletRequest, Collection<String>> authorizedServicesExtractor() {
        return (request) -> Collections.singletonList("divorce");
    }

--- a/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/service/token/ServiceTokenParserConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/service/token/ServiceTokenParserConfiguration.java
@@ -2,9 +2,7 @@ package uk.gov.hmcts.reform.auth.parser.idam.spring.service.token;
 
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -15,15 +13,14 @@ import uk.gov.hmcts.reform.auth.parser.idam.core.service.token.ServiceTokenParse
 @Lazy
 public class ServiceTokenParserConfiguration {
 
-    @Bean
-    @ConditionalOnMissingBean(name = "serviceTokenParserHttpClient")
+    @Bean("serviceTokenParserHttpClient")
     public CloseableHttpClient serviceTokenParserHttpClient() {
         return HttpClients.createDefault();
     }
 
     @Bean
     public ServiceTokenParser serviceAuthProviderAuthCheckClient(
-        @Qualifier("serviceTokenParserHttpClient") CloseableHttpClient serviceTokenParserHttpClient,
+        CloseableHttpClient serviceTokenParserHttpClient,
         @Value("${auth.provider.service.client.baseUrl}") String baseUrl) {
             return new HttpComponentsBasedServiceTokenParser(serviceTokenParserHttpClient, baseUrl);
     }

--- a/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/user/token/UserTokenParserConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/spring/user/token/UserTokenParserConfiguration.java
@@ -2,9 +2,7 @@ package uk.gov.hmcts.reform.auth.parser.idam.spring.user.token;
 
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -16,15 +14,14 @@ import uk.gov.hmcts.reform.auth.parser.idam.core.user.token.UserTokenParser;
 @Configuration
 public class UserTokenParserConfiguration {
 
-    @Bean
-    @ConditionalOnMissingBean(name = "userTokenParserHttpClient")
+    @Bean("userTokenParserHttpClient")
     public CloseableHttpClient userTokenParserHttpClient() {
         return HttpClients.createDefault();
     }
 
     @Bean
     public UserTokenParser<UserTokenDetails> userTokenParser(
-        @Qualifier("userTokenParserHttpClient") CloseableHttpClient userTokenParserHttpClient,
+        CloseableHttpClient userTokenParserHttpClient,
         @Value("${auth.idam.client.baseUrl}") String baseUrl) {
             return new HttpComponentsBasedUserTokenParser<>(userTokenParserHttpClient, baseUrl, UserTokenDetails.class);
     }

--- a/src/test/java/uk/gov/hmcts/reform/auth/checker/core/service/ServiceRequestAuthorizerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/auth/checker/core/service/ServiceRequestAuthorizerTest.java
@@ -47,7 +47,7 @@ class ServiceRequestAuthorizerTest {
         when(mockRequest.getHeader("ServiceAuthorization")).thenReturn(null);
 
         SubjectResolver<Service> mockSubjectResolver = subjectResolver("Bearer aa.bbbb.cccc", new Service("service-a"));
-        ServiceRequestAuthorizer serviceRequestAuthorizer = new ServiceRequestAuthorizer(mockSubjectResolver, (any) -> Arrays.asList("service-x", "service-a", "service-z"));
+        ServiceRequestAuthorizer serviceRequestAuthorizer = new ServiceRequestAuthorizer(mockSubjectResolver, any -> Arrays.asList("service-x", "service-a", "service-z"));
 
         assertThrows(BearerTokenMissingException.class, () -> serviceRequestAuthorizer.authorise(mockRequest));
     }
@@ -64,7 +64,7 @@ class ServiceRequestAuthorizerTest {
         when(request.getHeader("ServiceAuthorization")).thenReturn(bearerToken);
 
         SubjectResolver<Service> subjectResolver = subjectResolver(bearerToken, service);
-        ServiceRequestAuthorizer serviceRequestAuthorizer = new ServiceRequestAuthorizer(subjectResolver, (any) -> Arrays.asList(allowedPrincipals));
+        ServiceRequestAuthorizer serviceRequestAuthorizer = new ServiceRequestAuthorizer(subjectResolver, any -> Arrays.asList(allowedPrincipals));
 
         return serviceRequestAuthorizer.authorise(request);
     }

--- a/src/test/java/uk/gov/hmcts/reform/auth/checker/core/user/UserRequestAuthorizerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/auth/checker/core/user/UserRequestAuthorizerTest.java
@@ -25,7 +25,7 @@ import static org.mockito.internal.util.collections.Sets.newSet;
 class UserRequestAuthorizerTest {
 
     private final String userId = "1111-2222";
-    private final Function<HttpServletRequest, Optional<String>> extractUserIdFromRequest = (String) -> Optional.of(userId);
+    private final Function<HttpServletRequest, Optional<String>> extractUserIdFromRequest = String -> Optional.of(userId);
 
     @Test
     void testWhenAuthorisedRoleAndValidUserId() {
@@ -39,7 +39,7 @@ class UserRequestAuthorizerTest {
         SubjectResolver<User> mockSubjectResolver = mock(SubjectResolver.class);
         when(mockSubjectResolver.getTokenDetails(userBearerToken)).thenReturn(stubbedSubject);
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, (any) -> asList("role-a", "role-b", "role-c", "service-a"));
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, any -> asList("role-a", "role-b", "role-c", "service-a"));
 
         Subject actualSubject = userRequestAuthorizer.authorise(mockRequest);
 
@@ -50,7 +50,7 @@ class UserRequestAuthorizerTest {
     @Test
     void testWhenAuthorisedRoleAndNoUserIdInRequest() {
 
-        Function<HttpServletRequest, Optional<String>> noUserIdInRequest = (String) -> Optional.empty();
+        Function<HttpServletRequest, Optional<String>> noUserIdInRequest = String -> Optional.empty();
 
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         String userBearerToken = "Bearer aa.bbbb.cccc";
@@ -61,11 +61,11 @@ class UserRequestAuthorizerTest {
         SubjectResolver<User> mockSubjectResolver = mock(SubjectResolver.class);
         when(mockSubjectResolver.getTokenDetails(userBearerToken)).thenReturn(stubbedSubject);
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, noUserIdInRequest, (any) -> asList("role-a", "role-b", "role-c", "service-a"));
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, noUserIdInRequest, any -> asList("role-a", "role-b", "role-c", "service-a"));
 
         Subject actualSubject = userRequestAuthorizer.authorise(mockRequest);
 
-        assertThat((User) actualSubject, instanceOf(User.class));
+        assertThat(actualSubject, instanceOf(User.class));
         assertThat("Subjects don't match!", actualSubject, is(stubbedSubject));
     }
 
@@ -81,11 +81,11 @@ class UserRequestAuthorizerTest {
         SubjectResolver<User> mockSubjectResolver = mock(SubjectResolver.class);
         when(mockSubjectResolver.getTokenDetails(userBearerToken)).thenReturn(stubbedSubject);
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, (any) -> new ArrayList<>());
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, any -> new ArrayList<>());
 
         Subject actualSubject = userRequestAuthorizer.authorise(mockRequest);
 
-        assertThat((User) actualSubject, instanceOf(User.class));
+        assertThat(actualSubject, instanceOf(User.class));
         assertThat("Subjects don't match!", actualSubject, is(stubbedSubject));
     }
 
@@ -101,7 +101,7 @@ class UserRequestAuthorizerTest {
         SubjectResolver mockSubjectResolver = mock(SubjectResolver.class);
         when(mockSubjectResolver.getTokenDetails(userBearerToken)).thenReturn(stubbedSubject);
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, null, (any) -> asList("role-a", "role-b", "role-c"));
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, null, any -> asList("role-a", "role-b", "role-c"));
 
         assertThrows(UnauthorisedRoleException.class, () -> userRequestAuthorizer.authorise(mockRequest));
     }
@@ -118,7 +118,7 @@ class UserRequestAuthorizerTest {
         SubjectResolver<User> mockSubjectResolver = mock(SubjectResolver.class);
         when(mockSubjectResolver.getTokenDetails(userBearerToken)).thenReturn(stubbedSubject);
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, (any) -> asList("role-a", "role-b", "role-c"));
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, any -> asList("role-a", "role-b", "role-c"));
 
         assertThrows(UnauthorisedUserException.class, () -> userRequestAuthorizer.authorise(mockRequest));
     }
@@ -133,7 +133,7 @@ class UserRequestAuthorizerTest {
         SubjectResolver<User> mockSubjectResolver = mock(SubjectResolver.class);
         when(mockSubjectResolver.getTokenDetails(userBearerToken)).thenThrow(new IllegalArgumentException());
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, (any) -> asList("role-a", "role-b", "role-c"));
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, any -> asList("role-a", "role-b", "role-c"));
 
         assertThrows(IllegalArgumentException.class, () -> userRequestAuthorizer.authorise(mockRequest));
     }
@@ -145,7 +145,7 @@ class UserRequestAuthorizerTest {
 
         SubjectResolver<User> mockSubjectResolver = mock(SubjectResolver.class);
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, (any) -> asList("role-a", "role-b", "role-c"));
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, any -> asList("role-a", "role-b", "role-c"));
 
         assertThrows(BearerTokenMissingException.class, () -> userRequestAuthorizer.authorise(mockRequest));
     }
@@ -160,7 +160,7 @@ class UserRequestAuthorizerTest {
         SubjectResolver<User> mockSubjectResolver = mock(SubjectResolver.class);
         when(mockSubjectResolver.getTokenDetails(userBearerToken)).thenThrow(new IllegalArgumentException());
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, null, (any) -> asList("role-a", "role-b", "role-c"));
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, null, any -> asList("role-a", "role-b", "role-c"));
 
         assertThrows(IllegalArgumentException.class, () -> userRequestAuthorizer.authorise(mockRequest));
     }
@@ -175,7 +175,7 @@ class UserRequestAuthorizerTest {
         SubjectResolver<User> mockSubjectResolver = mock(SubjectResolver.class);
         when(mockSubjectResolver.getTokenDetails(userBearerToken)).thenThrow(new AuthenticationProviderUnavailableException());
 
-        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, (any) -> asList("role-a", "role-b", "role-c"));
+        UserRequestAuthorizer userRequestAuthorizer = new UserRequestAuthorizer(mockSubjectResolver, extractUserIdFromRequest, any -> asList("role-a", "role-b", "role-c"));
 
         assertThrows(AuthenticationProviderUnavailableException.class, () -> userRequestAuthorizer.authorise(mockRequest));
     }

--- a/src/test/java/uk/gov/hmcts/reform/auth/checker/spring/serviceanduser/ServiceAndUserTestApplication.java
+++ b/src/test/java/uk/gov/hmcts/reform/auth/checker/spring/serviceanduser/ServiceAndUserTestApplication.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -45,19 +44,17 @@ public class ServiceAndUserTestApplication {
     public class AuthCheckerConfiguration {
         @Bean
         public Function<HttpServletRequest, Optional<String>> userIdExtractor() {
-            return (request) -> Optional.of("user");
+            return request -> Optional.of("user");
         }
 
-        @Bean
-        @Qualifier("authorizedRolesExtractor")
+        @Bean("authorizedRolesExtractor")
         public Function<HttpServletRequest, Collection<String>> authorizedRolesExtractor() {
-            return (any) -> Collections.singletonList("citizen");
+            return any -> Collections.singletonList("citizen");
         }
 
-        @Bean
-        @Qualifier("authorizedServiceExtractor")
+        @Bean("authorizedServiceExtractor")
         public Function<HttpServletRequest, Collection<String>> authorizedServicesExtractor() {
-            return (any) -> Collections.singletonList("divorce");
+            return any -> Collections.singletonList("divorce");
         }
 
         @Bean
@@ -91,7 +88,7 @@ public class ServiceAndUserTestApplication {
         public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
             http
                 .addFilter(filter)
-                .authorizeHttpRequests((authorizeHttpRequests) ->
+                .authorizeHttpRequests(authorizeHttpRequests ->
                     authorizeHttpRequests.anyRequest().authenticated()
                 );
             return http.build();

--- a/src/test/java/uk/gov/hmcts/reform/auth/checker/spring/serviceonly/ServiceOnlyTestApplication.java
+++ b/src/test/java/uk/gov/hmcts/reform/auth/checker/spring/serviceonly/ServiceOnlyTestApplication.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.function.Function;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -40,10 +39,9 @@ public class ServiceOnlyTestApplication {
     @Configuration
     @EnableWebSecurity
     public class AuthCheckerConfiguration {
-        @Bean
-        @Qualifier("authorizedServiceExtractor")
+        @Bean("authorizedServiceExtractor")
         public Function<HttpServletRequest, Collection<String>> authorizedServicesExtractor() {
-            return (any) -> Collections.singletonList("divorce");
+            return any -> Collections.singletonList("divorce");
         }
 
         @Bean
@@ -71,7 +69,7 @@ public class ServiceOnlyTestApplication {
         public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
             http
                 .addFilter(filter)
-                .authorizeHttpRequests((authorizeHttpRequests) ->
+                .authorizeHttpRequests(authorizeHttpRequests ->
                     authorizeHttpRequests.anyRequest().authenticated()
                 );
             return http.build();

--- a/src/test/java/uk/gov/hmcts/reform/auth/checker/spring/useronly/UserOnlyTestApplication.java
+++ b/src/test/java/uk/gov/hmcts/reform/auth/checker/spring/useronly/UserOnlyTestApplication.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -43,13 +42,12 @@ public class UserOnlyTestApplication {
     public class AuthCheckerConfiguration {
         @Bean
         public Function<HttpServletRequest, Optional<String>> userIdExtractor() {
-            return (request) -> Optional.of("1");
+            return request -> Optional.of("1");
         }
 
-        @Bean
-        @Qualifier("authorizedRolesExtractor")
+        @Bean("authorizedRolesExtractor")
         public Function<HttpServletRequest, Collection<String>> authorizedRolesExtractor() {
-            return (any) -> Collections.singletonList("citizen");
+            return any -> Collections.singletonList("citizen");
         }
 
         @Bean
@@ -77,7 +75,7 @@ public class UserOnlyTestApplication {
         public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
             http
                 .addFilter(filter)
-                .authorizeHttpRequests((authorizeHttpRequests) ->
+                .authorizeHttpRequests(authorizeHttpRequests ->
                     authorizeHttpRequests.anyRequest().authenticated()
                 );
             return http.build();


### PR DESCRIPTION
Add names to `@Bean` annotations to allow removal of `@Qualifier` when declaring authorizedRolesExtractor or authorizedServiceExtractor beans.

Previously, we relied on `@Qualifier` annotations to specify which beans should be injected where multiple beans of the same type existed. 

By adding names to `@Bean` annotations we can now directly reference the beans by name without specifying `@Qualifier`.

E.g. 

`@Bean("authorizedRolesExtractor")`