### PR TITLE
Test adding -parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ java {
     }
 }
 
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }


### PR DESCRIPTION
Adding `-parameters` compiler flag to ensure Spring selects the correct bean:

https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#core-container