### PR TITLE
Use spring boot starter test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id "io.freefair.lombok" version "8.13.1"
+    id 'io.freefair.lombok' version '8.13.1'
 }
 
 def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "DEV-SNAPSHOT"
@@ -19,7 +19,7 @@ compileJava {
     options.compilerArgs << '-parameters'
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
 
@@ -29,21 +29,15 @@ repositories {
 }
 
 dependencies {
-    api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.3'
     api group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.4.3'
     api group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.6'
     api group: 'com.google.guava', name: 'guava', version: '33.4.6-jre'
-    api group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '3.4.4'
     api group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '3.4.4'
     api group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.4.4'
-    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.12.1'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.27.3'
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.12.1'
-    testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '3.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.17.0'
-    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.4.4'
+
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '3.4.4'
-    compileOnly group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '6.1.0'
+    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.12.1'
+
     compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.9.3'
 }
 
@@ -57,7 +51,7 @@ jar {
     }
 }
 
-task printVersion {
+tasks.register('printVersion') {
     doLast {
         print project.version
     }
@@ -77,12 +71,14 @@ def pomConfig = {
     }
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
+tasks.register('sourcesJar', Jar) {
+    dependsOn classes
     archiveClassifier = 'sources'
     from sourceSets.main.allSource
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
+tasks.register('javadocJar', Jar) {
+    dependsOn javadoc
     archiveClassifier = 'javadoc'
     from javadoc.destinationDir
 }
@@ -98,9 +94,9 @@ publishing {
             from components.java
             artifact sourcesJar
             artifact javadocJar
-            groupId project.group
-            artifactId 'auth-checker-lib'
-            version project.version
+            groupId = project.group
+            artifactId = 'auth-checker-lib'
+            version = project.version
 
             pom.withXml {
                 def root = asNode()
@@ -112,4 +108,3 @@ publishing {
         }
     }
 }
-

--- a/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/core/service/token/HttpComponentsBasedServiceTokenParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/core/service/token/HttpComponentsBasedServiceTokenParser.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.auth.parser.idam.core.service.token;
 
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.HttpResponse;
@@ -18,7 +18,7 @@ public class HttpComponentsBasedServiceTokenParser implements ServiceTokenParser
         this.baseUrl = baseUrl;
     }
 
-    @SuppressWarnings(value = "HTTP_PARAMETER_POLLUTION", justification = "baseUrl + /details is not based on user input")
+    @SuppressFBWarnings(value = "HTTP_PARAMETER_POLLUTION", justification = "baseUrl + /details is not based on user input")
     public String parse(String jwt) {
         try {
             String bearerJwt = jwt.startsWith("Bearer ") ? jwt : "Bearer " + jwt;

--- a/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/core/user/token/HttpComponentsBasedUserTokenParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/auth/parser/idam/core/user/token/HttpComponentsBasedUserTokenParser.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.auth.parser.idam.core.user.token;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.HttpResponse;
@@ -24,7 +24,7 @@ public class HttpComponentsBasedUserTokenParser<T> implements UserTokenParser<T>
     }
 
     @Override
-    @SuppressWarnings(value = "HTTP_PARAMETER_POLLUTION", justification = "baseUrl + /details is not based on user input")
+    @SuppressFBWarnings(value = "HTTP_PARAMETER_POLLUTION", justification = "baseUrl + /details is not based on user input")
     public T parse(String jwt) {
         try {
             String bearerJwt = jwt.startsWith("Bearer ") ? jwt : "Bearer " + jwt;


### PR DESCRIPTION
### Change description ###

The [spring-boot-starter-test dependency](https://docs.spring.io/spring-boot/reference/testing/test-scope-dependencies.html) already includes compatible versions of JUnit and manages the `BOM`, `API`, and `engine`. Therefore, there's no need to declare JUnit explicitly when using this starter.

In multiple repositories, I've observed that test events (e.g. IDE test discovery or reporting) can stop working when explicitly upgrading to JUnit versions > 5.12.x. This is likely due to incompatibilities introduced by bypassing Spring Boot's dependency management.

The [recommendation](https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle-bom) is to rely on spring-boot-starter-test when possible, and only use the JUnit BOM directly if you're not using Spring Boot's test starter.

This PR removes the redundant JUnit dependency and defers version management to Spring Boot.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
